### PR TITLE
Fix name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# botkit-slack-helper
+# botkit-helper-slack
 #### Helps Slack bots get their point across
 
 
@@ -6,7 +6,7 @@ Never have to look up how to use **bold**, *italics*, ~~strikethrough~~, `code`,
 
 ### Getting started
 ```sh
-$ npm install --save botkit-slack-helper
+$ npm install --save botkit-helper-slack
 ```
 ___
 ### Usage


### PR DESCRIPTION
It looks like the package was renamed at some point from `botkit-slack-helper` to `botkit-helper-slack`.

Everything else works well otherwise!